### PR TITLE
Improve armour tonnage allocation.

### DIFF
--- a/src/main/java/org/lisoft/lsml/command/CmdDistributeArmour.java
+++ b/src/main/java/org/lisoft/lsml/command/CmdDistributeArmour.java
@@ -138,9 +138,8 @@ public class CmdDistributeArmour extends CompositeCommand {
         final ArmourUpgrade armourUpgrade = aLoadout.getUpgrades().getArmour();
         final double unarmouredMass = aLoadout.getMassStructItems();
         final double requestedArmourMass = aPointsOfArmour / armourUpgrade.getArmourPerTon();
-        final double expectedLoadoutMass = Math.floor((unarmouredMass + requestedArmourMass) * 2) / 2; // Round down to
-                                                                                                       // closest half
-                                                                                                       // ton
+        // Round down to the nearest MASS_QUANTA.
+        final double expectedLoadoutMass = Math.floor((unarmouredMass + requestedArmourMass) / MASS_QUANTA) * MASS_QUANTA;
         final double expectedArmourMass = expectedLoadoutMass - unarmouredMass;
         int armourLeft = (int) (expectedArmourMass * armourUpgrade.getArmourPerTon());
 

--- a/src/main/java/org/lisoft/lsml/command/CmdDistributeArmour.java
+++ b/src/main/java/org/lisoft/lsml/command/CmdDistributeArmour.java
@@ -44,7 +44,7 @@ import org.lisoft.lsml.util.CommandStack.CompositeCommand;
  * @author Emily Björk
  */
 public class CmdDistributeArmour extends CompositeCommand {
-    public static final double MASS_QUANTA = 0.5;
+    public static final double MASS_QUANTA = 0.25;
     private final Map<Location, Integer> armours = new HashMap<>(Location.values().length);
     private final Loadout loadout;
     private final int totalPointsOfArmour;

--- a/src/test/java/org/lisoft/lsml/command/CmdDistributeArmourTest.java
+++ b/src/test/java/org/lisoft/lsml/command/CmdDistributeArmourTest.java
@@ -435,7 +435,7 @@ public class CmdDistributeArmourTest {
     }
 
     /**
-     * Values that are not even half tons shall be rounded down.
+     * Values that are not even quarter tons shall be rounded down.
      */
     @Test
     public void testArmourDistributor_RoundDown() throws Exception {
@@ -443,13 +443,13 @@ public class CmdDistributeArmourTest {
         final LoadoutStandard loadout = (LoadoutStandard) loadoutFactory.produceEmpty(ChassisDB.lookup("HGN-733C"));
         // 90 tons, 9 tons internals
 
-        // Execute (10.75 tons of armour)
-        final CmdDistributeArmour cut = new CmdDistributeArmour(loadout, 32 * 10 + 16 + 8, 1.0, xBar);
+        // Execute (10.8125 tons of armour)
+        final CmdDistributeArmour cut = new CmdDistributeArmour(loadout, 32 * 10 + 26, 1.0, xBar);
         stack.pushAndApply(cut);
 
         // Verify
-        final double evenHalfTons = (int) (loadout.getMass() * 2.0) / 2.0;
-        final double diffTons = loadout.getMass() - evenHalfTons;
+        final double evenQuarterTons = (int) (loadout.getMass() * 4.0) / 4.0;
+        final double diffTons = loadout.getMass() - evenQuarterTons;
         assertTrue(Math.abs(diffTons) < loadout.getUpgrades().getArmour().getArmourMass(1));
     }
 
@@ -467,23 +467,7 @@ public class CmdDistributeArmourTest {
         stack.pushAndApply(cut);
 
         // Verify
-        assertEquals(544, loadout.getArmour());
-    }
-
-    /**
-     * The operation shall round down to the closest half ton, even if quarter ton items are present.
-     */
-    @Test
-    public void testArmourDistributor_RoundDownQuarterTons() throws Exception {
-        // Setup
-        final Loadout loadout = loadLink("lsml://rgC0CCwECQc7BSwECAAP6zHaJmuzrtq69oNmgrsUyma7Wuws");
-
-        // Execute
-        final CmdDistributeArmour cut = new CmdDistributeArmour(loadout, 192, 8.0, xBar);
-        stack.pushAndApply(cut);
-
-        // Verify
-        assertEquals(184, loadout.getArmour());
+        assertEquals(552, loadout.getArmour());
     }
 
     /**


### PR DESCRIPTION
Unlike tabletop, MWO tracks armour weight at a per-point granularity,
instead of at half-ton boundaries. Since the lightest equipment weighs
0.25 tons, we should be rounding our armour weights accordingly.

(also includes a fix to actually use the MASS_QUANTA constant)