### PR TITLE
Improve engine rating/type selection.

### DIFF
--- a/src/main/java/org/lisoft/lsml/model/database/ItemDB.java
+++ b/src/main/java/org/lisoft/lsml/model/database/ItemDB.java
@@ -113,7 +113,15 @@ public class ItemDB {
         if (aType == EngineType.XL && aFaction == Faction.CLAN) {
             sb.append("CLAN ");
         }
-        sb.append(aType.name()).append(" ENGINE ").append(aRating);
+
+        if (aType == EngineType.LE) {
+            sb.append("LIGHT");
+        }
+        else {
+            sb.append(aType.name());
+        }
+
+        sb.append(" ENGINE ").append(aRating);
         return (Engine) lookup(sb.toString());
     }
 

--- a/src/main/java/org/lisoft/lsml/model/item/EngineType.java
+++ b/src/main/java/org/lisoft/lsml/model/item/EngineType.java
@@ -26,4 +26,23 @@ package org.lisoft.lsml.model.item;
  */
 public enum EngineType {
     XL, LE, STD;
+
+    public int minRating() {
+        if (this == XL) {
+            return 100;
+        } else if (this == LE) {
+            return 100;
+        } else if (this == STD) {
+            return 60;
+        }
+
+        throw new IllegalArgumentException();
+    }
+
+    /**
+     * Clamp an engine rating into an EngineType's available range.
+     */
+    public int clampRating(int aRating) {
+        return aRating < minRating() ? minRating() : aRating;
+    }
 }

--- a/src/main/java/org/lisoft/lsml/model/item/EngineType.java
+++ b/src/main/java/org/lisoft/lsml/model/item/EngineType.java
@@ -26,11 +26,4 @@ package org.lisoft.lsml.model.item;
  */
 public enum EngineType {
     XL, LE, STD;
-
-    @Deprecated // Semantically this only makes sense when there are exactly two types.
-    public EngineType otherType() {
-        if (this == XL)
-            return STD;
-        return XL;
-    }
 }

--- a/src/test/java/org/lisoft/lsml/model/item/EngineTypeTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/EngineTypeTest.java
@@ -1,0 +1,50 @@
+/*
+ * @formatter:off
+ * Li Song Mechlab - A 'mech building tool for PGI's MechWarrior: Online.
+ * Copyright (C) 2013  Emily Björk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+//@formatter:on
+package org.lisoft.lsml.model.item;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class EngineTypeTest {
+
+    @Test
+    public void testClampRating() {
+        assertEquals(EngineType.XL.minRating(), EngineType.XL.clampRating(0));
+        assertEquals(EngineType.LE.minRating(), EngineType.LE.clampRating(0));
+        assertEquals(EngineType.STD.minRating(), EngineType.STD.clampRating(0));
+
+        assertEquals(EngineType.XL.minRating(), EngineType.XL.clampRating(EngineType.XL.minRating() - 5));
+        assertEquals(EngineType.LE.minRating(), EngineType.LE.clampRating(EngineType.LE.minRating() - 5));
+        assertEquals(EngineType.STD.minRating(), EngineType.STD.clampRating(EngineType.STD.minRating() - 5));
+
+        assertEquals(EngineType.XL.minRating() + 5, EngineType.XL.clampRating(EngineType.XL.minRating() + 5));
+        assertEquals(EngineType.LE.minRating() + 5, EngineType.LE.clampRating(EngineType.LE.minRating() + 5));
+        assertEquals(EngineType.STD.minRating() + 5, EngineType.STD.clampRating(EngineType.STD.minRating() + 5));
+    }
+
+    @Test
+    public void testMinRating() {
+        assertEquals(100, EngineType.XL.minRating());
+        assertEquals(100, EngineType.LE.minRating());
+        assertEquals(60, EngineType.STD.minRating());
+    }
+
+}

--- a/src/test/java/org/lisoft/lsml/model/item/ItemLookupTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/ItemLookupTest.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import org.junit.Test;
 import org.lisoft.lsml.model.NoSuchItemException;
 import org.lisoft.lsml.model.database.ItemDB;
+import org.lisoft.lsml.model.item.EngineType;
+import org.lisoft.lsml.model.item.Faction;
 
 /**
  * Test suite for {@link ItemDB}.
@@ -57,6 +59,19 @@ public class ItemLookupTest {
 
         // Lookup by MWO name key (ducked up case)
         assertSame(expected, ItemDB.lookup("EnGine_stD_105"));
+    }
+
+    @Test
+    public void testGetEngine() throws Exception {
+        // Setup
+        final String name = "LIGHT ENGINE 105";
+        final Item expected = ItemDB.lookup(name);
+
+        // Lookup by name
+        assertNotNull(ItemDB.lookup(name));
+
+        // Lookup by ItemDb.getEngine().
+        assertSame(expected, ItemDB.getEngine(105, EngineType.LE, Faction.INNERSPHERE));
     }
 
     @Test

--- a/src/test/java/org/lisoft/lsml/model/item/ItemLookupTest.java
+++ b/src/test/java/org/lisoft/lsml/model/item/ItemLookupTest.java
@@ -63,15 +63,9 @@ public class ItemLookupTest {
 
     @Test
     public void testGetEngine() throws Exception {
-        // Setup
-        final String name = "LIGHT ENGINE 105";
-        final Item expected = ItemDB.lookup(name);
-
-        // Lookup by name
-        assertNotNull(ItemDB.lookup(name));
-
-        // Lookup by ItemDb.getEngine().
-        assertSame(expected, ItemDB.getEngine(105, EngineType.LE, Faction.INNERSPHERE));
+        for (Engine engine : ItemDB.lookup(Engine.class)) {
+            assertSame(engine, ItemDB.getEngine(engine.getRating(), engine.getType(), engine.getFaction()));
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix two bugs:
 - Switch the XL checkbox to a dropdown that includes light engines.
 - Filter the engine rating dropdown to engines that exist.

Fixes #733.